### PR TITLE
feat: add map commands

### DIFF
--- a/src/data/commands.ts
+++ b/src/data/commands.ts
@@ -521,6 +521,17 @@ const commands = [
      ]
    },
    {
+     "name": "disable_maps",
+     "type": "Admin",
+     "description": "Disable the map feature",
+     "usage": [
+      "/disable_maps [game]",
+     ],
+     "examples": [
+         "/disable_maps Custom",
+     ]
+   },
+   {
      "name": "remove_map",
      "type": "Admin",
      "description": "Remove a map",

--- a/src/data/commands.ts
+++ b/src/data/commands.ts
@@ -498,6 +498,39 @@ const commands = [
           "/rolling_queue Enabled",
       ]
     },
+   {
+     "name": "maps",
+     "type": "Admin",
+     "description": "Enable maps for a Specific game",
+     "usage": [
+      "/maps [map_selection] [game]",
+     ],
+     "examples": [
+         "/maps Random Custom",
+     ]
+   },
+   {
+     "name": "add_map",
+     "type": "Admin",
+     "description": "Add a map to your server map pool",
+     "usage": [
+      "/add_map [name] (game_mode) [image_url] [game]",
+     ],
+     "examples": [
+         "/add_map Rust Domination https://i.imgur/abcdef.jpg Custom",
+     ]
+   },
+   {
+     "name": "remove_map",
+     "type": "Admin",
+     "description": "Remove a map",
+     "usage": [
+      "/remove_map [map_name]",
+     ],
+     "examples": [
+         "/remove_map Rust",
+     ]
+   },
 
   // ~ Set-up
   {
@@ -661,6 +694,17 @@ const commands = [
     ],
     "examples": [
       "/refresh_challenges",
+    ]
+  },
+  {
+    "name": "list_maps",
+    "type": "General",
+    "description": "List all maps available on the server",
+    "usage": [
+      "/list_maps",
+    ],
+    "examples": [
+      "/list_maps",
     ]
   },
   // ~ Games


### PR DESCRIPTION
/maps - This command will enable maps for your selected games. Once activated, a random map will be sent into your voice lobby for every game.
/disable_maps - Disables maps. Maps will no longer be sent.
/add_map - Add a map to your server pool. Select 
/remove_map - Remove a map from your server pool.
/list_maps - List all maps available on your server.