### PR TITLE
fix: force stats revalidation on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,6 @@ ENV PORT 3000
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
 CMD \
   # if INVALIDATE_SECRET is not set, generate a random secret
-  INVALIDATE_SECRET=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1) \
+  INVALIDATE_SECRET=${INVALIDATE_SECRET:-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)} \
   HOSTNAME="0.0.0.0" \
   node server.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   bot:
@@ -26,10 +26,12 @@ services:
       - "3000:3000"
     networks:
       - inhouse-network
+    depends_on:
+      - website-stats
 
   website-stats:
     build:
-      context: ../website-stats  # https://github.com/InHouseQueue/website-stats
+      context: ../website-stats # https://github.com/InHouseQueue/website-stats
       dockerfile: Dockerfile
     image: website-stats
     container_name: website-stats
@@ -43,7 +45,6 @@ services:
 networks:
   inhouse-network:
     external: true
-
 
 volumes:
   redis-data:

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ import withBundleAnalyzer from "@next/bundle-analyzer";
 /** @type {import("next").NextConfig} */
 const config = {
   reactStrictMode: true,
-  experimental: {},
+  experimental: { instrumentationHook: true },
   output: 'standalone',
 
   // svgr

--- a/src/app/api/invalidate/route.ts
+++ b/src/app/api/invalidate/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from "next/server";
+import { env } from "../../../env.mjs";
+import { revalidateTag } from "next/cache";
+
+export const POST = (request: NextRequest) => {
+  if (request.headers.get("Authorization") !== env.INVALIDATE_SECRET) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  revalidateTag("stats");
+  console.log("Revalidated stats tag");
+  return new Response("OK", { status: 200 });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,14 +17,14 @@ export default function HomePage() {
 
       <Banner image={banner} height="67vh">
         <div className="mb-28 mt-24 flex flex-col justify-center gap-3 text-center sm:mb-8 sm:mt-0 md:mb-0">
-{/*           <h2 className="text-xl font-bold text-slate-200">Presenting</h2> */}
-{/*           <h1 className="text-4xl font-bold text-white" data-aos="zoom-out"> */}
-{/*             In-House Queue */}
-{/*           </h1> */}
-{/*           <p className="text-xl text-slate-200"> */}
-{/*             A Discord Bot Designed to organize In-House Custom Games. Currently */}
-{/*             in beta. */}
-{/*           </p> */}
+          {/*           <h2 className="text-xl font-bold text-slate-200">Presenting</h2> */}
+          {/*           <h1 className="text-4xl font-bold text-white" data-aos="zoom-out"> */}
+          {/*             In-House Queue */}
+          {/*           </h1> */}
+          {/*           <p className="text-xl text-slate-200"> */}
+          {/*             A Discord Bot Designed to organize In-House Custom Games. Currently */}
+          {/*             in beta. */}
+          {/*           </p> */}
 
           {/* buttons */}
           <div className="mt-64 flex flex-row flex-wrap justify-center gap-8">

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,75 @@
+import { env } from "./env.mjs";
+
+export function register() {
+  // wait for stats service to be ready, then revalidate stats data
+  void waitForStatsService().finally(() => void attemptSelfRevalidation());
+}
+
+/**
+ * Polls the STATS_ENDPOINT until it's ready, at a max of 10 attempts
+ * @param attempt
+ * @returns
+ */
+async function waitForStatsService(attempt = 0) {
+  if (attempt > 10) {
+    console.log(
+      "[warn] Stats service not ready after 10 attempts! Using stale data.",
+    );
+    return false;
+  }
+
+  try {
+    await fetch(env.STATS_ENDPOINT);
+    return true;
+  } catch (err) {
+    console.log("[debug] Stats service not ready, retrying...");
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        waitForStatsService(attempt + 1)
+          .then(() => resolve(true))
+          .catch(() => resolve(true));
+      }, attempt * 150);
+    });
+  }
+}
+
+/**
+ * Makes an API call to the src/apps/api/revalidate/route.ts
+ * Used to mark certain data (i.e. stats) as stale since they were generated at build time
+ * Follows up with a request to the homepage to trigger a regeneration
+ * Not the nicest solution, but Next.JS doesn't allow invalidateTag to run
+ * @param attempt
+ * @returns
+ */
+async function attemptSelfRevalidation(attempt = 0) {
+  console.log(`Attempt ${attempt} to revalidate.`);
+
+  if (attempt > 10) {
+    console.log("Max attempts reached, no longer revalidating");
+    return;
+  }
+
+  try {
+    // PORT environment variable is automatically set by Next.JS, even if not explicitly defined or if --port CLI flag is used.
+    await fetch(
+      `http://127.0.0.1:${process.env.PORT ?? "3000"}/api/invalidate`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: env.INVALIDATE_SECRET,
+        },
+      },
+    )
+      .then((res) => res.text())
+      .then((data) => console.log(data));
+
+    // Next.JS only allows for invalidation, so we must make a request to trigger Next.JS to regenerate the page
+    await fetch(`http://127.0.0.1:${process.env.PORT ?? "3000"}/`);
+  } catch (err) {
+    console.log("Failed to revalidate");
+    console.error(err);
+
+    setTimeout(() => void attemptSelfRevalidation(attempt + 1), attempt * 100);
+  }
+}

--- a/src/partials/Home/StatCards.tsx
+++ b/src/partials/Home/StatCards.tsx
@@ -32,8 +32,6 @@ async function fetchStatistics() {
   } catch (err) {
     console.error("Failed to fetch statistics: ", err);
     return null;
-  } finally {
-  console.log("Fetched statistics");
   }
 }
 


### PR DESCRIPTION
On server startup, it will poll the stats endpoint until it responds, then the server will request itself on `/api/invalidate` to invalidate the "stats" tag. Next.JS will [only revalidate the data on the *next* request](https://nextjs.org/docs/14/app/api-reference/functions/revalidateTag) with seemingly no way to override this, so the server will then request itself on the homepage, triggering Next.JS to attempt to refetch the data and regenerate the page.

To prevent external access to the `/api/invalidate` endpoint, a `INVALIDATE_SECRET` environment variable has been introduced. **No action is needed though**, as the Dockerfile will auto-generate one on build.

Furthermore, a `depends_on` parameter was added to the docker-compose.yml file so that the webserver starts only after the stats service is online.